### PR TITLE
removed unused loop for asyncio-timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'async-timeout~=4.0',
-        'bitstring~=3.1',
-        'pyserial-asyncio~=0.6',
+        'async-timeout>=4.0',
+        'bitstring>=3.1',
+        'pyserial-asyncio>=0.6',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'async-timeout>=3.0.1',
-        'bitstring>=3.1.5',
-        'pyserial-asyncio>=0.4',
+        'async-timeout~=4.0',
+        'bitstring~=3.1',
+        'pyserial-asyncio~=0.6',
     ],
 )

--- a/sml/asyncio.py
+++ b/sml/asyncio.py
@@ -104,7 +104,7 @@ class SmlProtocol(SmlBase, asyncio.Protocol):
             await self._disconnect()
             await asyncio.sleep(delay, loop=self._loop)
             try:
-                async with timeout(5, loop=self._loop):
+                async with timeout(5):
                     self._transport, _ = await self._create_connection()
             except (BrokenPipeError, ConnectionRefusedError,
                     SerialException, asyncio.TimeoutError) as exc:


### PR DESCRIPTION
I removed the parameter loop from asyncio-timeout call. This parameter ahs been removed in version 4 of asyncio-timeout and is now braking the installation using pip.

Furthermore is set fixed version for dependencies in setup.py so that in future new version of used libs does not break this package again.