### PR TITLE
Fix reconnection

### DIFF
--- a/sml/asyncio.py
+++ b/sml/asyncio.py
@@ -86,7 +86,6 @@ class SmlSerialProtocol(SmlBase, asyncio.Protocol):
 
     def connection_lost(self, exc: Optional[Exception]):
         logger.debug('port closed')
-        self._transport = None
         if self._running and not self._lock.locked():
             asyncio.ensure_future(self._reconnect(), loop=self._loop)
 


### PR DESCRIPTION
Hi,

as some other people I had a problem with the EDL21 component of homeassistant (home-assistant/core#98409). After some time (random) no data are available anymore. The (info) log will show a lot of reconnection, but nothing happen. One way to fix it, is to restart the hole homeassistant.
I spent some time to find out the reason. One indicator was, that the led on my serial adapter was still active. So the serial port must be opened. Then I had created a custom component with a local copy of all libraries and add some debug messages to be able to follow the code.
Now I have simple removed one statement, which remove the reference to the transport before it is closed. Another idea was to close the connection before this line, if the exc parameter was a TimeoutError. But then the _disconnect function will never abort the transport and I used this way, now. Please feel free to comment and will try to adjust the path as fast as possible. Hope to get rid of this neasty problem ;-)

If the watchdog trigger connection_lost and the serial connection if already open, it was not possible to close/abort the connection.
Old:
- Watchdog timout
- connection_lost (transport set to None)
- _reconnect
  - _disconnect (which could not abort, because transport not set anymore)
  - _create_connection Call pyserial-asyncio: create_serial_connection -> _ensure_reader -> _read_ready -> _close -> connection_lost (end here, because of lock)

New workflow could abort the transport and the new connection will work. Anyway connection_lost will be called twice:
1. by the watchdog (with TimeoutError)
2. by _reconnect -> _disconnect -> abort

The last one will do nothing more, because of the lock of _reconnect.