### PR TITLE
Fix missing event loop in `test_asyncio.py`

### DIFF
--- a/examples/test_asyncio.py
+++ b/examples/test_asyncio.py
@@ -49,7 +49,8 @@ def main(url):
     handler = SmlEvent()
     proto = SmlProtocol(url)
     proto.add_listener(handler.event, ['SmlGetListResponse'])
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     loop.run_until_complete(proto.connect(loop))
     loop.run_forever()
 


### PR DESCRIPTION
Fixes the following exception:

```
Traceback (most recent call last):
  File "/tmp/github.com/mtdcr/pysml/examples/./test_asyncio.py", line 63, in <module>
    main(argv[1])
    ~~~~^^^^^^^^^
  File "/tmp/github.com/mtdcr/pysml/examples/./test_asyncio.py", line 52, in main
    loop = asyncio.get_event_loop()
  File "/usr/lib64/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
                       % threading.current_thread().name)
RuntimeError: There is no current event loop in thread 'MainThread'.
```